### PR TITLE
ci: Don't run check drone signature workflow in forks

### DIFF
--- a/.github/workflows/drone-signature-check.yml
+++ b/.github/workflows/drone-signature-check.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   drone-signature-check:
+    # only run in grafana/tempo.
+    if: github.repository == 'grafana/tempo'    
     uses: grafana/shared-workflows/.github/workflows/check-drone-signature.yaml@main
     with:
       drone_config_path: .drone/drone.yml


### PR DESCRIPTION
**What this PR does**:

saw this workflow run and fail in my fork, restrict this workflow to only grafana/tempo

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`